### PR TITLE
Potential fixed mobile resize and typing accessibility.

### DIFF
--- a/get-ur-tickets/src/App.css
+++ b/get-ur-tickets/src/App.css
@@ -283,31 +283,35 @@ body{
 }
 
 .suggestions {
-  position: absolute;
+  position: relative;
   top: 65%;
   background-color: white;
   border: 1px solid #ccc;
   width: 41.8%; 
-  max-height: 200px;
+  max-height: 240px;
   overflow-y: auto;
   z-index: 100;
+  display:flex;
 }
 
 .suggestions button {
   display: block;
   width: 100%;
-  padding: 10px;
+  padding: 5px;
   border: none;
   background: #f9f9f9;
   text-align: left;
   font-size: 14px;
-  cursor: pointer;
 }
 
 .suggestions button:hover {
   background-color: #e6e6e6;
 }
 
+#focus  {
+  background-color : #74d4fa;
+  color: black;
+}
 
 
 /* Start of second row that will contain the left segment with settings buttons and containers for ticket information*/
@@ -339,15 +343,12 @@ body{
 .Second-Row-Ticket-Background{
   flex: 1;
   position: relative;
-  width: 100vw;
+  width: auto;
   height: auto;
-  background-color: rgb(15, 15, 15); 
+  background-color: rgb(0, 0, 0); 
 }
 
 .Ticket-Box{
-  width: 99%;
-  height: 15vh;
-  padding-bottom: 10%;
   background-color: rgb(255, 255, 255); 
   border-radius: 8px;
 }

--- a/get-ur-tickets/src/Components/AirportSearchBar.js
+++ b/get-ur-tickets/src/Components/AirportSearchBar.js
@@ -22,7 +22,7 @@ const AirportSearchBar = ({ onSelect }) => {
 
   const handleFocus = (e) => {
     console.log(e.key);
-    if(e.repeat && e.key !== "Backspace"){
+    if(e.repeat && e.key !== "Backspace"){ //This will print the first key pressed but block all after execpt for backspace
       console.log("while");
       e.preventDefault();
       e.tabIndex = 0;
@@ -78,10 +78,9 @@ const AirportSearchBar = ({ onSelect }) => {
       setcheckEscape(true);
       setcheckKeys(0);
     }
-    if (listRef.current && checkKeys >= 0) {
+    if (listRef.current && checkKeys >= 0) { //without this suggestion box will not scroll with tab or arrow keys
       const activeItem = listRef.current.children[checkKeys];
       if (activeItem) {
-        
         activeItem.scrollIntoView({ block: 'nearest' });
       }
     }

--- a/get-ur-tickets/src/Components/AirportSearchBar.js
+++ b/get-ur-tickets/src/Components/AirportSearchBar.js
@@ -87,7 +87,7 @@ const AirportSearchBar = ({ onSelect }) => {
       }
     }
     console.log(checkKeys)
-  }, [searchTerm, checkKeys, checkEscape]);
+  }, [searchTerm, checkKeys, checkEscape, prevKey]);
 
   const handleSearch = (event) => {
     const term = event.target.value;

--- a/get-ur-tickets/src/Components/AirportSearchBar.js
+++ b/get-ur-tickets/src/Components/AirportSearchBar.js
@@ -14,6 +14,7 @@ const AirportSearchBar = ({ onSelect }) => {
   const [checkEscape, setcheckEscape] = useState(true); //used with handle escape and useeffect to exit suggestions box with escape key
   const [checkKeys, setcheckKeys] = useState(0);
   const [errorMessage, setErrorMessage] = useState('');
+  const [prevKey, setprevKey] = useState(''); //used to store the previous key used so when you click escape to close suggestion it does not instantly reappear
   const listRef = useRef(null);
   SearchBar.originAirportCode = location;
   const airports = airportData; // Imported JSON data
@@ -22,6 +23,7 @@ const AirportSearchBar = ({ onSelect }) => {
 
   const handleFocus = (e) => {
     console.log(e.key);
+    setprevKey(e.key);
     if(e.repeat && e.key !== "Backspace"){ //This will print the first key pressed but block all after execpt for backspace
       console.log("while");
       e.preventDefault();
@@ -74,7 +76,7 @@ const AirportSearchBar = ({ onSelect }) => {
   //if there is any changes in the airport search bar the suggestions should come back
   useEffect(() => {
     setErrorMessage('');
-    if(checkEscape === false){
+    if(checkEscape === false && prevKey !== 'Escape'){
       setcheckEscape(true);
       setcheckKeys(0);
     }
@@ -85,7 +87,7 @@ const AirportSearchBar = ({ onSelect }) => {
       }
     }
     console.log(checkKeys)
-  }, [searchTerm, checkKeys]);
+  }, [searchTerm, checkKeys, checkEscape]);
 
   const handleSearch = (event) => {
     const term = event.target.value;

--- a/get-ur-tickets/src/Components/AirportSearchBar.js
+++ b/get-ur-tickets/src/Components/AirportSearchBar.js
@@ -1,22 +1,97 @@
-import React, { useState, useContext } from 'react';
+import React, { useState, useContext, useEffect, useRef } from 'react';
 import PropTypes from 'prop-types'; // Import PropTypes
 import airportData from '../airportData_flatui.json'; // Import JSON
 import { LocationContext } from '../index';           // Import context
 import '../AirportSearchBar.css';
 import SearchBar from './SearchBar';
+
 export var test = "";
 export var test2 ="";
 const AirportSearchBar = ({ onSelect }) => {
   const {location, setLocation } = useContext(LocationContext);
   const [searchTerm, setSearchTerm] = useState('');
   const [filteredAirports, setFilteredAirports] = useState([]);
-
+  const [checkEscape, setcheckEscape] = useState(true); //used with handle escape and useeffect to exit suggestions box with escape key
+  const [checkKeys, setcheckKeys] = useState(0);
+  const [errorMessage, setErrorMessage] = useState('');
+  const listRef = useRef(null);
   SearchBar.originAirportCode = location;
   const airports = airportData; // Imported JSON data
+
+  //if the escape key is pressed set checkEscape to false so suggestion box closes
+
+  const handleFocus = (e) => {
+    console.log(e.key);
+    if(e.repeat && e.key !== "Backspace"){
+      console.log("while");
+      e.preventDefault();
+      e.tabIndex = 0;
+      return;
+    }
+    e.target.focus({preventScroll: true});
+    if(e.key === 'ArrowUp' && checkKeys > 0){
+      e.target.blur();
+      e.preventDefault();
+      e.target.focus({preventScroll: true});
+      setcheckKeys(prevIndex => Math.max(prevIndex - 1, 0));
+    }
+    else if(e.key === 'ArrowDown'){
+      e.target.blur();
+      e.preventDefault();
+      e.target.focus({preventScroll: true});
+      setcheckKeys(prevIndex => Math.min(prevIndex + 1, filteredAirports.length - 1));
+    }
+    else if(e.key === "Enter" && filteredAirports.length !== 0){
+      handleSelect(filteredAirports[checkKeys])
+    }
+    else if (e.key === "Enter" && filteredAirports.length === 0){
+      setErrorMessage('Error selecting airport: Airport not found.');
+    }
+    else if(e.key === "Tab"){
+      console.log("HERE");
+      if(e.shiftKey){
+        if(checkKeys !== 0){
+          e.target.blur();
+          e.preventDefault();
+          e.target.focus({preventScroll: true});
+        }
+        setcheckKeys(prevIndex => Math.max(prevIndex - 1, 0));
+      }
+      else{
+      if(checkKeys !== parseInt(filteredAirports.length - 1)){  
+          e.target.blur();
+          e.preventDefault();
+          e.target.focus({preventScroll: true});
+        }
+        setcheckKeys(prevIndex => Math.min(prevIndex + 1, filteredAirports.length - 1));
+      }
+    }
+    else if(e.key === 'Escape' && checkEscape){
+      setcheckEscape(false);
+    }
+  }
+
+  //if there is any changes in the airport search bar the suggestions should come back
+  useEffect(() => {
+    setErrorMessage('');
+    if(checkEscape === false){
+      setcheckEscape(true);
+      setcheckKeys(0);
+    }
+    if (listRef.current && checkKeys >= 0) {
+      const activeItem = listRef.current.children[checkKeys];
+      if (activeItem) {
+        
+        activeItem.scrollIntoView({ block: 'nearest' });
+      }
+    }
+    console.log(checkKeys)
+  }, [searchTerm, checkKeys]);
 
   const handleSearch = (event) => {
     const term = event.target.value;
     setSearchTerm(term);
+    setcheckKeys(0);
 
     // Clear the populated suggestions if the user has not entered anything
     if (term.trim() === '') {
@@ -44,23 +119,32 @@ const AirportSearchBar = ({ onSelect }) => {
     console.log(airport);
   };
 
+
   return (
     <div className="Airport-search-bar">
       <div className='description' >Enter your Home Airport. Currently set to: {test2}</div>
       <input
+        aria-labelledby='Airport Search Bar'
         style={{width: '42%', alignItems: 'center'}}
         type="text"
         value={searchTerm}
         onChange={handleSearch}
         placeholder="Search for an airport..."
+        onKeyDown={handleFocus}
       />
-      {searchTerm && filteredAirports.length > 0 && (
-        <div className="suggestions" >
-          {filteredAirports.map((airport) => (
-            <button 
+      {errorMessage && (
+            <div className='error-message'>{errorMessage}</div> // display Error Message
+      )}
+      {searchTerm && filteredAirports.length > 0 && checkEscape && (
+        <div tabIndex = {0} ref={listRef} className="suggestions" >
+          {filteredAirports.map((airport, index) => (
+            <button
+              onKeyDown={handleFocus}
               key={airport.iata_code || airport.municipality || airport.name}
-              onClick={() => handleSelect(airport)}
-              
+              id={checkKeys === index ? 'focus' : console.log(checkKeys + "   " + airport.iata_code + " " + parseInt(filteredAirports.length - 1)   + "  " + index + " !!!!")}
+              tabIndex={checkKeys === parseInt(filteredAirports.length - 1)  && checkKeys === index ? -1 : checkKeys === index ? 0 : -1 }
+              onClick={() => handleSelect(airport)
+              }
             >
               {airport.name} ({airport.iata_code})
             </button>

--- a/get-ur-tickets/src/Components/Header.js
+++ b/get-ur-tickets/src/Components/Header.js
@@ -31,7 +31,7 @@ const Header = () => {
     }, []);
 
     return (
-        <header className="bg-dark text-white fixed-top py-2">
+        <header className="bg-dark text-white fixed-top py-2" style={{}}>
             <div className="container d-flex align-items-center">
                 <div className="col justify-content-start">
                     <div className="d-flex align-items-center">
@@ -48,7 +48,7 @@ const Header = () => {
                             to="/home"
                             className="text-white text-decoration-none"
                             style={{
-                                fontSize: isScrolled ? '1.5rem' : '2.5rem', // Text size change on scroll
+                                fontSize: isScrolled ? '1.5rem' : '1.5rem', // Text size change on scroll
                                 transition: 'font-size 0.3s ease',
                             }}
                         >

--- a/get-ur-tickets/src/Components/Header.js
+++ b/get-ur-tickets/src/Components/Header.js
@@ -31,7 +31,7 @@ const Header = () => {
     }, []);
 
     return (
-        <header className="bg-dark text-white fixed-top py-2" style={{}}>
+        <header className="bg-dark text-white fixed-top py-2" >
             <div className="container d-flex align-items-center">
                 <div className="col justify-content-start">
                     <div className="d-flex align-items-center">

--- a/get-ur-tickets/src/Components/SearchBar.js
+++ b/get-ur-tickets/src/Components/SearchBar.js
@@ -58,6 +58,11 @@ const SearchBar = ({ onSearchResults }) => {
 
 
   const handleKeyPress = (e) => {
+    if(e.repeat && e.key !== "Backspace"){
+      e.preventDefault();
+      e.tabIndex = 0;
+      return;
+    }
     if (e.key === 'Enter'){
         handleSearch();
     }
@@ -73,12 +78,13 @@ const SearchBar = ({ onSearchResults }) => {
     <div className="search-section">
       <div className="search-bar-container">
       <TextField
+        aria-labelledby='Event Search Bar'
         disabled = {test === '' ? true : false}
         className="search-input"
         variant="outlined"
         value={searchTerm}
         onChange={handleInputChange}
-        onKeyUpCapture={handleKeyPress}
+        onKeyDown={handleKeyPress}
         placeholder="Search for an Event..."
         input={{
           endAdornment: searchTerm && (

--- a/get-ur-tickets/src/Components/TicketGenerator.js
+++ b/get-ur-tickets/src/Components/TicketGenerator.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import DetailsPopover from "../Components/popOver.tsx";
-    
+import Container from "react-bootstrap/Container";
+
     export var chkMore = false;
     export var chkLess = false;
 
@@ -55,17 +56,21 @@ import DetailsPopover from "../Components/popOver.tsx";
     
     startRender(){
             return (
-            <div className="Ticket-Box" 
+            <Container fluid className="Ticket-Box" 
             style=
             {{       
-                height: 'auto', 
+                height: 'auto',
+                width:'99%',
+                maxWidth: '99%',
                 display: 'flex', 
                 justifyContent: 'space-between', 
-                padding: '20px', 
-                border: '1px solid #ddd', 
-                margin: '10px 0' 
+                padding: '0',
+                marginBottom: '.5%',
+                marginLeft:'.5%',
+                marginRight:'.5%',
+                marginTop:'0',
             }}>
-            <div style=
+            <div className="col" style=
             {{ 
                 flex: 1, 
                 textAlign: 'left', 
@@ -73,6 +78,7 @@ import DetailsPopover from "../Components/popOver.tsx";
                 Width: '19vw',
                 maxWidth: '19vw',
                 color: 'black',
+                wordBreak: 'break-all'
             }}>
                 <strong>Location:</strong>
                 <br/> {this.eventlocation}     
@@ -86,6 +92,7 @@ import DetailsPopover from "../Components/popOver.tsx";
                 Width: '19vw',
                 maxWidth: '19vw',
                 color: 'black',
+                wordBreak: 'break-all'
             }}>
                 <strong>Event Price:</strong> {'$' + this.tempHoldEvent.toFixed(2)}
                 <br/>
@@ -103,6 +110,7 @@ import DetailsPopover from "../Components/popOver.tsx";
                 Width: '19vw',
                 maxWidth: '19vw',
                 color: 'black',
+                wordBreak: 'break-all'
             }}>
                 <strong>Flight Price:
                 </strong> {'$' + this.tempHoldFlight.toFixed(2)}
@@ -130,6 +138,7 @@ import DetailsPopover from "../Components/popOver.tsx";
                 Width: '19vw',
                 maxWidth: '19vw',
                 color: 'black',
+                wordBreak: 'break-all'
             }}>
                 <strong>Flight Price:N/A-Home Loaction</strong>
             </div>
@@ -144,6 +153,7 @@ import DetailsPopover from "../Components/popOver.tsx";
                 Width: '19vw',
                 maxWidth: '19vw',
                 color: 'black',
+                wordBreak: 'break-all'
             }}>
                 <strong>Hotel Price:</strong> {'$' + this.tempHoldHotel.toFixed(2)}
                 <br/>
@@ -162,6 +172,7 @@ import DetailsPopover from "../Components/popOver.tsx";
                 Width: '19vw',
                 maxWidth: '19vw',
                 color: 'black',
+                wordBreak: 'break-all'
             }}>
                 <strong>Hotel Price: N/A-Home Location</strong>
                 <br/>
@@ -173,14 +184,15 @@ import DetailsPopover from "../Components/popOver.tsx";
             <div style=
             {{ 
                 flex: 1, 
-                textAlign: 'right', 
+                textAlign: 'left', 
                 Width: '19vw',
                 maxWidth: '19vw',
                 color: 'black',
+                wordBreak: 'break-all'
             }}>
                 <strong>Estimated Total Price:</strong> {"$" + this.tempHoldTotal.toFixed(2)}
             </div>
-            </div>
+            </Container>
             )
         /*this will be used to create the display ticket with prices, location, link, etc... */
     };

--- a/get-ur-tickets/src/pages/Contact Us.js
+++ b/get-ur-tickets/src/pages/Contact Us.js
@@ -33,7 +33,7 @@ export function Contact() {
     <Container fluid className='banner-container' style={{ padding: "0%", margin: "0%"}}>
       {/* Banner Section */}
       <div>
-        <div className="d-flex flex-column justify-content-center align-items-center" style={{ height: '50vh' }}>
+        <div className="d-flex flex-column justify-content-center align-items-center" style={{ paddingTop:'5%' }}>
         <img src={NewLogo} alt="Logo" className="img-fluid" style={{ maxWidth: '200px', height: 'auto' }} />
         <div className="text-center mt-3" style={{ fontSize: '4rem', fontFamily: 'sans-serif' }}>
           GET UR TICKETS

--- a/get-ur-tickets/src/pages/Home.js
+++ b/get-ur-tickets/src/pages/Home.js
@@ -107,9 +107,9 @@ export function Home() {
 
 
   return (
-    <Container fluid className='banner-container' style={{padding: "0%", margin:"0%", overflowX: 'hidden'}}>
+    <Container fluid className='banner-container' style={{padding: "0%", margin:"0%", overflowX: 'hidden', height:'auto'}}>
       <div>
-        <div className="d-flex flex-column justify-content-center align-items-center" style={{ height: '50vh' }}>
+        <div className="d-flex flex-column justify-content-center align-items-center" style={{ paddingTop:'5%' }}>
           <img src={NewLogo} alt="Logo" className="img-fluid" style={{ maxWidth: '200px', height: 'auto' }} />
           <div className="text-center mt-3" style={{ fontSize: '4rem', fontFamily: 'sans-serif' }}>
               GET UR TICKETS

--- a/get-ur-tickets/src/pages/Login.js
+++ b/get-ur-tickets/src/pages/Login.js
@@ -20,13 +20,13 @@ export function Login() {
             {/* About Us Text */}
             <div className="container-md text-center">
                 <h1 className="text-primary text-white mb-3">About Us</h1>
-                <h2 className="text-secondary text-white mb-3">
+                <h2 className="text-dark text-white mb-3">
                     Our team has built this project to seek a better alternative to inflated venue ticket costs.
                     In some scenarios, it may be more cost-effective to purchase a vacation package to see your
                     favorite artist on tour in lieu of seeing them in your home city.
                 </h2>
                 <br />
-                <h2 className="text-secondary text-white mb-4">
+                <h2 className="text-dark text-white mb-4">
                     This web application will allow you to explore events including flights and hotels from
                     aggregated data via third parties, all in one place for transparency and your convenience.
                     To access our search engine, please login or create an account below.

--- a/get-ur-tickets/src/pages/Login.js
+++ b/get-ur-tickets/src/pages/Login.js
@@ -9,7 +9,7 @@ export function Login() {
         /* Bootstrap container */
         <Container fluid className='banner-container' style={{padding: "0%", margin:"0%", overflowX: 'hidden'}}>
             <div>
-                <div className="d-flex flex-column justify-content-center align-items-center" style={{ height: '50vh' }}>
+                <div className="d-flex flex-column justify-content-center align-items-center" style={{ paddingTop:'5%' }}>
                     <img src={NewLogo} alt="Logo" className="img-fluid" style={{ maxWidth: '200px', height: 'auto' }} />
                     <div className="text-center mt-3" style={{ fontSize: '4rem', fontFamily: 'sans-serif' }}>
                         GET UR TICKETS
@@ -36,7 +36,7 @@ export function Login() {
 
             {/* Authention */}
             <div className="d-flex justify-content-center">
-                <div className="w-50">
+                <div className="w-55">
                     <Authenticator />
                 </div>
             </div>


### PR DESCRIPTION
## Describe your changes
In airportsearchbar you can traverse the suggestion box with tab or arrow keys. 
Added an error message to airportsearchbar if you do not have suggested airport selected.
Holding a key will no longer constantly print use that key unless it is backspace for airportsearchbar and searchbar.
Adjusted resize for containers to work for mobile. It worked with smallest firefox and chrome sizes.

## Images (if applicable)
### Before


### After


## I have tested my code
- [x] Yes
- [ ] No. Reason: 

## Did you update the README
- [ ] Yes
- [x] No. Reason: 